### PR TITLE
Force UTF-8 to correctly parse Unicode chars

### DIFF
--- a/parse-slack-export.ps1
+++ b/parse-slack-export.ps1
@@ -9,8 +9,8 @@ $rebuildhash = $false #rebuild the dm hash even if it's not empty
 Clear-Host
 $directories = $null
 
-$dms = Get-Content ($exportPath + "dms.json") | ConvertFrom-Json
-$Global:users = Get-Content ($exportPath + "users.json") | ConvertFrom-Json
+$dms = Get-Content -Encoding "UTF8" ($exportPath + "dms.json") | ConvertFrom-Json
+$Global:users = Get-Content -Encoding "UTF8" ($exportPath + "users.json") | ConvertFrom-Json
 #region Unused API stuff
 <#
 Was using the APIs for info before I noticed the files in the root export folder.
@@ -96,7 +96,7 @@ foreach($directory in $directories) {
         New-Item -Force $htmlFile
         $jsonFiles = Get-ChildItem $directory.FullName -Exclude *.html
         foreach($jsonFile in $jsonFiles) {
-            $jsonObjs = Get-Content $jsonFile.FullName | ConvertFrom-Json
+            $jsonObjs = Get-Content -Encoding "UTF8" $jsonFile.FullName | ConvertFrom-Json
             foreach($jsonObj in $jsonObjs) {
                 $message = $null
                 $timestamp = $null


### PR DESCRIPTION
Thank you for your incredibly useful tool.

During using it I've noticed that some accented characters (ěščřžýáíé) were being parsed incorrectly. Forcing encoding "UTF8" for all Get-Content calls fixes it.